### PR TITLE
Compatibility with base 4.11 (GHC 8.4.1)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,24 @@
+.PHONY: build install
+
+build:
+	stack build
+
+install:
+	stack install
+
+# Testing
+.PHONY: test test-all test-default test-%
+
+test-all: test-default test-7.10.3 test-7.8.4 test-8.0.2 test-8.2.2
+
+test: test-default
+
+test-default:
+	stack clean
+	stack build
+	stack haddock --no-haddock-deps
+
+test-%:
+	stack --stack-yaml stack-$*.yaml clean
+	stack --stack-yaml stack-$*.yaml build
+	stack --stack-yaml stack-$*.yaml haddock --no-haddock-deps

--- a/Text/PrettyPrint/Leijen.hs
+++ b/Text/PrettyPrint/Leijen.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE CPP #-}
+{-# LANGUAGE OverlappingInstances #-}
 -----------------------------------------------------------------------------
 -- |
 -- Module      :  Text.PrettyPrint.Leijen

--- a/Text/PrettyPrint/Leijen.hs
+++ b/Text/PrettyPrint/Leijen.hs
@@ -119,6 +119,10 @@ import System.IO (Handle,hPutStr,hPutChar,stdout)
 import Prelude hiding ((<$>))
 #endif
 
+#if !MIN_VERSION_base(4,11,0)
+import Data.Monoid (Monoid(..))
+#endif
+
 infixr 5 </>,<//>,<$>,<$$>
 infixr 6 <+>
 #if !MIN_VERSION_base(4,11,0)
@@ -319,6 +323,10 @@ instance Semigroup Doc where
 (<>) :: Doc -> Doc -> Doc
 x <> y          = x `beside` y
 #endif
+
+instance Monoid Doc where
+  mempty = empty
+  mappend = (<>)
 
 -- | The document @(x \<+\> y)@ concatenates document @x@ and @y@ with a
 -- @space@ in between.  (infixr 6)

--- a/Text/PrettyPrint/Leijen.hs
+++ b/Text/PrettyPrint/Leijen.hs
@@ -119,8 +119,10 @@ import Prelude hiding ((<$>))
 #endif
 
 infixr 5 </>,<//>,<$>,<$$>
-infixr 6 <>,<+>
-
+infixr 6 <+>
+#if !MIN_VERSION_base(4,11,0)
+infixr 6 <>
+#endif
 
 -----------------------------------------------------------
 -- list, tupled and semiBraces pretty print a list of
@@ -309,8 +311,13 @@ fold f ds       = foldr1 f ds
 -- | The document @(x \<\> y)@ concatenates document @x@ and document
 -- @y@. It is an associative operation having 'empty' as a left and
 -- right unit.  (infixr 6)
+#if MIN_VERSION_base(4,11,0)
+instance Semigroup Doc where
+  x <> y          = x `beside` y
+#else
 (<>) :: Doc -> Doc -> Doc
 x <> y          = x `beside` y
+#endif
 
 -- | The document @(x \<+\> y)@ concatenates document @x@ and @y@ with a
 -- @space@ in between.  (infixr 6)

--- a/stack-7.10.3.yaml
+++ b/stack-7.10.3.yaml
@@ -1,0 +1,6 @@
+resolver: ghc-7.10.3
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/stack-7.8.4.yaml
+++ b/stack-7.8.4.yaml
@@ -1,0 +1,6 @@
+resolver: ghc-7.8.4
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/stack-8.0.2.yaml
+++ b/stack-8.0.2.yaml
@@ -1,0 +1,6 @@
+resolver: ghc-8.0.2
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/stack-8.2.2.yaml
+++ b/stack-8.2.2.yaml
@@ -1,0 +1,6 @@
+resolver: ghc-8.2.2
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,0 +1,6 @@
+resolver: ghc-8.4.1
+packages:
+- '.'
+extra-deps: []
+flags: {}
+extra-package-dbs: []

--- a/wl-pprint.cabal
+++ b/wl-pprint.cabal
@@ -16,7 +16,6 @@ Build-Type:          Simple
 Library
   Build-Depends:       base < 5
   Exposed-Modules:     Text.PrettyPrint.Leijen
-  Extensions:          OverlappingInstances
 
 source-repository head
   type: git


### PR DESCRIPTION
Also added some instances (`Monoid` and `Semigroup`), and moved the `OverlappingInstances`language extension to the source file.

I added some stack files to help with testing with different GHC versions. With a functioning stack setup, the project can be built with different versions of GHC with `make test-all`.

EDIT: See also https://github.com/sinelaw/wl-pprint/issues/4